### PR TITLE
PHP 5.3 compatibility

### DIFF
--- a/ZboziKonverze.php
+++ b/ZboziKonverze.php
@@ -308,7 +308,7 @@ class ZboziKonverze {
     protected function sendRequest($url)
     {
         $encoded_json = json_encode(get_object_vars($this));
-        
+
         if (extension_loaded('curl'))
         {
             $ch = curl_init();
@@ -317,7 +317,7 @@ class ZboziKonverze {
             curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 3 /* seconds */);
             curl_setopt($ch, CURLOPT_POST, 1);
             curl_setopt($ch, CURLOPT_POSTFIELDS, $encoded_json);
-            curl_setopt($ch, CURLOPT_HTTPHEADER, ['Content-Type: application/json']);
+            curl_setopt($ch, CURLOPT_HTTPHEADER, array('Content-Type: application/json'));
             $response = curl_exec($ch);
 
             if ($response === false) {


### PR DESCRIPTION
Mám tady drobnou změnum která knihovnu zprovozní na PHP 5.3. Ano vím, že je to příliš stará verze PHP. Ale na jednom stařičkém projektu jsem na tuto nekompatibilitu narazil. A pokud jednořádnová změna syntaxe pole pomůže, snad by nemusel být problém s přijetím pull requestu. Děkuji!