### PR TITLE
Introduced basic composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,8 @@
+{
+    "name": "seznam/zbozi-konverze",
+    "type": "library",
+    "license": "MIT",
+    "autoload": {
+        "classmap": ["ZboziKonverze.php"]
+    }
+}


### PR DESCRIPTION
Přidal jsem základní `composer.json`, aby se třída dala nainstalovat přes composer. I jen s takovýmhle základním půjde třída použít přes `"type": "vcs"`. Ještě lepší by ale bylo commit otagovat nějakou verzí a přidat do packagistu. Šlo by? Díky 👍 